### PR TITLE
Additional Install Script

### DIFF
--- a/install_ubuntu.sh
+++ b/install_ubuntu.sh
@@ -1,0 +1,7 @@
+INSTALL_DIR="/usr/share/gtksourceview-3.0/styles"
+
+echo "Installing Gedit themes..."
+
+sudo cp ./*.xml $INSTALL_DIR/.
+
+echo "All done!"


### PR DESCRIPTION
the install script provided gave me the following error:

<pre>cp: target `/home/andy/.local/share/gedit/styles/.' is not a directory</pre>

It seems that gedit sits in my file system differently than in yours.
I wrote an install script that works for my OS and gedit versions:
ubuntu 12.10
gedit 3.6.1
it is included in the directory as install_ubuntu.sh
